### PR TITLE
fix(vnstat): panic when not enough data available

### DIFF
--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -122,6 +122,10 @@ func TrafficVnstat() (uint64, uint64, error) {
 		return 0, 0, err
 	}
 	vData := strings.Split(BytesToString(buf), ";")
+ 	if len(vData) != 15 {
+		// Not enough data available yet.
+		return 0, 0, nil
+	}
 	rx, err := strconv.ParseUint(vData[8], 10, 64)
 	if err != nil {
 		return 0, 0, err


### PR DESCRIPTION
When using vnstat first time or without persistent data (such as openwrt with data stored in flash), the output of the command `vnstat --oneline` at startup will be:

```bash
# vnstat --oneline
 enp2s0: Not enough data available yet.
```
and the indexing operation in the code will cause panic.

And the man page of vnstat says "The output contains **15** fields with ; used as field delimiter".

	  --oneline [mode]
		  Show traffic summary for selected interface using one line with a parsable format. The output contains 15 fields with ; used as field delimiter.

